### PR TITLE
add --no-single-mask

### DIFF
--- a/aggregate_prefixes/__main__.py
+++ b/aggregate_prefixes/__main__.py
@@ -69,6 +69,12 @@ def main() -> None:
         default=128
     )
     parser.add_argument(
+        '--no-single-mask', '-n',
+        dest='no_single_mask',
+        help="Don't add CIDR mask for individual IPs (/32, /128)",
+        action='store_true'
+    )
+    parser.add_argument(
         '--verbose', '-v',
         help='Display verbose information about the optimisations',
         action='store_true'
@@ -100,9 +106,18 @@ def main() -> None:
     except (ValueError, TypeError) as error:
         sys.exit(f'ERROR: {error}')
 
-    # Cast aggregates to `str` and print one per line
+    def prepare_output(prefix):
+        if args.no_single_mask:
+            if (prefix.version == 4 and prefix.prefixlen == 32) or (prefix.version == 6 and prefix.prefixlen == 128):
+                return(str(prefix).split('/')[0])
+            else:
+                return(str(prefix))
+        else:
+            return(str(prefix))
+
+    # Process aggregates and print one per line
     print(
-        '\n'.join(map(str, aggregates))
+        '\n'.join(map(prepare_output, aggregates))
     )
 
 


### PR DESCRIPTION
I've removed it via sed so far. Maybe it doesn't even matter apart from filesize. nftables is already verbose enough with the useless wrapper required for a simple list. ("",) I don't know what is faster in every case, so I added a switch. That single if to parse the flag should not incur any cost, if unwanted.

small file, 43 lines, 10000 it
map: avg run CPU time: 0.0533028 +0.924%
for loop: avg run CPU time: 0.0528146

large file, 91294 lines, 150 it
map: avg run CPU time: 4.4011133
for loop: avg run CPU time: 4.4267933 +0.583%
The results are odd, the map should be faster. Guess not even CPU time is deterministic enough for a 1% difference. I kept the map.